### PR TITLE
fix #28 - adding NL between lines

### DIFF
--- a/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
@@ -10,6 +10,6 @@
 {% if mailhogHostname %}    - {{ mailhogHostname }}{{ "\n" }}{% endif %}
 {% if mysqlHostname %}    - {{ mysqlHostname }}{{ "\n" }}{% endif %}
 {% if postgresHostname %}    - {{ postgresHostname }}{{ "\n" }}{% endif %}
-{% if redisHostname %}    - {{ redisHostname }}{% endif %}
+{% if redisHostname %}    - {{ redisHostname }}}{{ "\n" }}{% endif %}
 {% if elasticsearchHostname %}    - {{ elasticsearchHostname }}{% endif %}
 {% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
@@ -10,6 +10,6 @@
 {% if mailhogHostname %}    - {{ mailhogHostname }}{{ "\n" }}{% endif %}
 {% if mysqlHostname %}    - {{ mysqlHostname }}{{ "\n" }}{% endif %}
 {% if postgresHostname %}    - {{ postgresHostname }}{{ "\n" }}{% endif %}
-{% if redisHostname %}    - {{ redisHostname }}}{{ "\n" }}{% endif %}
+{% if redisHostname %}    - {{ redisHostname }}{{ "\n" }}{% endif %}
 {% if elasticsearchHostname %}    - {{ elasticsearchHostname }}{% endif %}
 {% endif %}


### PR DESCRIPTION
in the links: `redis` & `elasticsearch` container names