### PR TITLE
Promote dev logging config to all envs

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -90,3 +90,14 @@ stof_doctrine_extensions:
         default:
             timestampable: true
             sluggable: true
+
+monolog:
+    handlers:
+        main:
+            type: error_log
+            level: error
+            channels: [!event]
+        console:
+            type:   console
+            bubble: false
+            channels: [!event, !doctrine]

--- a/app/config/config_dev.yml
+++ b/app/config/config_dev.yml
@@ -10,14 +10,3 @@ framework:
 web_profiler:
     toolbar: true
     intercept_redirects: false
-
-monolog:
-    handlers:
-        main:
-            type: error_log
-            level: debug
-            channels: [!event]
-        console:
-            type:   console
-            bubble: false
-            channels: [!event, !doctrine]


### PR DESCRIPTION
This makes the app log errors only, on to error_log. This automagically makes docker logs work on all envs.