### PR TITLE
Support phalcon 3 on php 7.0

### DIFF
--- a/src/AppBundle/Resources/public/css/base.css
+++ b/src/AppBundle/Resources/public/css/base.css
@@ -234,6 +234,11 @@ label {
     font-size : 0.9em;
 }
 
+option:disabled {
+    background-color : #ccc;
+    font-style       : italic;
+}
+
 /***** Buttons *****/
 
 .button-custom {

--- a/src/AppBundle/Resources/public/js/main-form.js
+++ b/src/AppBundle/Resources/public/js/main-form.js
@@ -112,21 +112,6 @@ function doMainFormMagic() {
         }
     });
 
-    // Phalcon supports PHP 5.6 only
-    var applicationType = $('#project_applicationOptions_applicationType');
-    var hiddenFieldId   = 'hidden-phpversion';
-    var form            = $('#generator');
-
-    applicationType.change(function () {
-        if ($(this).val() == 'phalcon') {
-            phpVersionSelector.val('5.6.x').change().prop('disabled', true).parent().parent().effect('bounce');
-            $('<input>').attr('type', 'hidden').appendTo(form).attr('id', hiddenFieldId).attr('name', phpVersionSelector.attr('name')).val(phpVersionSelector.val());
-        } else if (phpVersionSelector.prop('disabled') == true) {
-            phpVersionSelector.prop('disabled', false).parent().parent().effect('bounce');
-            $('#' + hiddenFieldId).remove();
-        }
-    });
-
     // Analytics
     $('#generator').submit(function (event) {
         $('input[type=checkbox]').each(function () {

--- a/src/AppBundle/Resources/public/js/main-form.js
+++ b/src/AppBundle/Resources/public/js/main-form.js
@@ -112,8 +112,52 @@ function doMainFormMagic() {
         }
     });
 
+    // Phalcon supports PHP 5.6/7.0 only - proper jquery spaghetti, remove as soon as 7.1 is supported
+    /*** HACK ***/
+    var applicationType = $('#project_applicationOptions_applicationType');
+    var hiddenFieldId   = 'hidden-phpversion';
+    var form            = $('#generator');
+
+    applicationType.change(function () {
+        var hiddenField = $('#' + hiddenFieldId);
+
+        if ($(this).val() == 'phalcon') {
+            var supportedVersion = '5.6.x';
+            if (phpVersionSelector.val() == '7.1.x') {
+                supportedVersion = '7.0.x'
+            }
+
+            phpVersionSelector.val(supportedVersion).change();
+            phpVersionSelector.parent().parent().effect('bounce');
+            phpVersionSelector.children().each(function () {
+                if (this.value == '7.1.x') {
+                    $(this).prop('disabled', true);
+                }
+            });
+
+            $('<input>').attr('type', 'hidden').appendTo(form).attr('id', hiddenFieldId).attr('name', phpVersionSelector.attr('name')).val(phpVersionSelector.val());
+        } else {
+            phpVersionSelector.children().each(function () {
+                if (this.value == '7.1.x') {
+                    $(this).prop('disabled', false);
+                }
+            });
+
+            hiddenField.remove();
+        }
+    });
+
+    phpVersionSelector.change(function () {
+        var hiddenField = $('#' + hiddenFieldId);
+        if (hiddenField.length) {
+            hiddenField.val(phpVersionSelector.val());
+        }
+    });
+
+    /*** END OF HACK ***/
+
     // Analytics
-    $('#generator').submit(function (event) {
+    form.submit(function (event) {
         $('input[type=checkbox]').each(function () {
             ga('send', 'event', 'builder-form', 'builder-choices', $(this).attr('name'), $(this).is(':checked'));
         });

--- a/src/PHPDocker/Project/ServiceOptions/Application.php
+++ b/src/PHPDocker/Project/ServiceOptions/Application.php
@@ -38,7 +38,7 @@ class Application
     const ALLOWED_APPLICATION_TYPES = [
         self::APPLICATION_TYPE_GENERIC => 'Generic: Zend, Laravel, Lumen...',
         self::APPLICATION_TYPE_SYMFONY => 'Symfony 2/3',
-        self::APPLICATION_TYPE_PHALCON => 'Phalcon 2 (PHP 5.6 only)',
+        self::APPLICATION_TYPE_PHALCON => 'Phalcon 3 (PHP 5.6/7.0 only)',
     ];
 
     /**

--- a/src/PHPDocker/Project/ServiceOptions/Php.php
+++ b/src/PHPDocker/Project/ServiceOptions/Php.php
@@ -39,14 +39,14 @@ class Php extends Base
     const PHP_VERSION_71 = '7.1.x';
 
     /**
-     * @var array
-     */
-    protected $extensions = [];
-
-    /**
      * PHP 5.6.x
      */
     const PHP_VERSION_56 = '5.6.x';
+
+    /**
+     * @var array
+     */
+    protected $extensions = [];
 
     /**
      * Supported PHP versions

--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -17,16 +17,18 @@ RUN apt-get update \
 {% endif %}
 
 {% if applicationType == 'phalcon' %}
-    {% if phpVersion == '5.6.x' %}
-        {% set phalconPackage = 'php5-phalcon' %}
-    {% else %}
-        {% set phalconPackage = 'php7.0-phalcon' %}
-    {% endif %}
+    {% spaceless %}
+        {% if phpVersion == '5.6.x' %}
+            {% set phalconPackage = 'php5-phalcon' %}
+        {% else %}
+            {% set phalconPackage = 'php7.0-phalcon' %}
+        {% endif %}
+    {% endspaceless %}
 
 # Install phalcon
-RUN curl -s https://packagecloud.io/install/repositories/phalcon/stable/script.deb.sh | sudo bash \
+RUN curl -s https://packagecloud.io/install/repositories/phalcon/stable/script.deb.sh | bash \
     && apt-get update \
-    && apt-get install {{ phalconPackage }} \
+    && apt-get install -y {{ phalconPackage }} \
     && {{ cleanupCommand }}
 {% endif %}
 

--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -17,12 +17,16 @@ RUN apt-get update \
 {% endif %}
 
 {% if applicationType == 'phalcon' %}
+    {% if phpVersion == '5.6.x' %}
+        {% set phalconPackage = 'php5-phalcon' %}
+    {% else %}
+        {% set phalconPackage = 'php7.0-phalcon' %}
+    {% endif %}
+
 # Install phalcon
-RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1E569794 \
-    && echo "deb http://ppa.launchpad.net/phalcon/stable/ubuntu wily main" > /etc/apt/sources.list.d/phalcon.list \
+RUN curl -s https://packagecloud.io/install/repositories/phalcon/stable/script.deb.sh | sudo bash \
     && apt-get update \
-    && apt-get install php5-phalcon \
-    && php5enmod phalcon \
+    && apt-get install {{ phalconPackage }} \
     && {{ cleanupCommand }}
 {% endif %}
 


### PR DESCRIPTION
 * Add support for phalcon 3 on php 5.6 and 7.0
 * Use phalcon's installation script instead of vat-grown, bastardised ubuntu ppa (on debian)