### PR TITLE
Refactor folder structure

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,8 @@ services:
     image: phpdockerio/nginx:latest
     container_name: phpdocker-io-webserver
     volumes:
-        - ..:/var/www/phpdocker-io
-        - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+        - .:/var/www/phpdocker-io
+        - ./phpdocker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
      - "10000:80"
     links:
@@ -36,11 +36,11 @@ services:
   php-fpm:
     build:
       context: .
-      dockerfile: php-fpm/Dockerfile
+      dockerfile: phpdocker/php-fpm/Dockerfile
     container_name: phpdocker-io-php-fpm
     volumes:
-      - ..:/var/www/phpdocker-io
-      - ./php-fpm/php-ini-overrides.ini:/etc/php/7.1/fpm/conf.d/99-overrides.ini
+      - .:/var/www/phpdocker-io
+      - ./phpdocker/php-fpm/php-ini-overrides.ini:/etc/php/7.1/fpm/conf.d/99-overrides.ini
     links:
       - memcached
       - mailhog

--- a/src/PHPDocker/Generator/Generator.php
+++ b/src/PHPDocker/Generator/Generator.php
@@ -70,10 +70,10 @@ class Generator
             ->zipArchiver
             ->addFile($this->getReadmeMd($project))
             ->addFile($this->getReadmeHtml($project))
-            ->addFile($this->getDockerCompose($project))
             ->addFile($this->getPhpDockerConf($project))
             ->addFile($this->getPhpIniOverrides($project))
-            ->addFile($this->getNginxConf($project));
+            ->addFile($this->getNginxConf($project))
+            ->addFile($this->getDockerCompose($project), true);
 
         return $this->zipArchiver->generateArchive(sprintf('%s.zip', $project->getProjectNameSlug()));
     }

--- a/src/PHPDocker/Template/README.md.twig
+++ b/src/PHPDocker/Template/README.md.twig
@@ -3,11 +3,11 @@ PHPDocker.io generated environment
 
 #Add to your project#
 
-  * Unzip the file.
-  * Move the `phpdocker` folder into your project. You may rename this folder (see note below)
-  * Ensure the webserver config on `docker\nginx.conf` is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance `web/app|app_dev.php` on a Symfony project, or `public/index.php` on generic apps.
+Simply, unzip the file into your project, this will create `docker-compose.yml` on the root of your project and a folder named `phpdocker` containing nginx and php-fpm config for it.
 
-Note: you may place the files elsewhere in your project. Make sure you modify the volume linking on `docker-compose.yml` for both the webserver and php-fpm so that the folder being shared into the container is the root of your project.
+Ensure the webserver config on `docker\nginx.conf` is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance `web/app|app_dev.php` on a Symfony project, or `public/index.php` on generic apps.
+
+Note: you may place the files elsewhere in your project. Make sure you modify the locations for the php-fpm dockerfile, the php.ini overrides and nginx config on `docker-compose.yml` if you do so.
  
 #How to run#
 
@@ -16,7 +16,7 @@ Dependencies:
   * Docker engine v1.13 or higher. Your OS provided package might be a little old, if you encounter problems, do upgrade. See [https://docs.docker.com/engine/installation](https://docs.docker.com/engine/installation)
   * Docker compose v1.12 pr higher. See [docs.docker.com/compose/install](https://docs.docker.com/compose/install/)
 
-Once you're done, simply `cd` to the folder where you placed the files, then `docker-compose up -d`. This will initialise and start all the containers, then leave them running in the background.
+Once you're done, simply `cd` to your project and run `docker-compose up -d`. This will initialise and start all the containers, then leave them running in the background.
 
 ##Services exposed outside your environment##
 
@@ -50,4 +50,14 @@ php-fpm|{{ phpFpmContainerName }}|9000
   * Stop containers: `docker-compose stop`
   * Kill containers: `docker-compose kill`
   * View container logs: `docker-compose logs`
-  * Execute command inside of container: `docker exec -it {{ phpFpmContainerName }} COMMAND` where `COMMAND` is whatever you want to run. For instance, `/bin/bash` to open a console prompt.
+  * Execute command inside of container: `docker-compose exec SERVICE_NAME COMMAND` where `COMMAND` is whatever you want to run. Examples:
+        * Shell into the PHP container, `docker-compose exec php-fpm bash`
+        * Run symfony console, `docker-compose exec php-fpm bin/console`
+        * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
+
+#Recommendations#
+
+It's hard to avoid file permission issues when fiddling about with containers due to the fact that, from your OS point of view, any files created within the container are owned by the process that runs the docker engine (this is usually root). Different OS will also have different problems, for instance you can run stuff in containers using `docker exec -it -u $(id -u):$(id -g) CONTAINER_NAME COMMAND` to force your current user ID into the process, but this will only work if your host OS is Linux, not mac. Follow a couple of simple rules and save yourself a world of hurt.
+
+  * Run composer outside of the php container, as doing so would install all your dependencies owned by `root` within your vendor folder.
+  * Run commands (ie Symfony's console, or Laravel's artisan) straight inside of your container. You can easily open a shell as described above and do your thing from there.

--- a/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
@@ -10,12 +10,12 @@
     php-fpm:
       build:
         context: .
-        dockerfile: php-fpm/Dockerfile
+        dockerfile: phpdocker/php-fpm/Dockerfile
       container_name: {{ phpFpmContainerName }}
       working_dir: /application
       volumes:
-        - ..:/application
-        - ./{{ phpIniOverrides }}:{{ iniLocation }}99-overrides.ini
+        - .:/application
+        - ./phpdocker/{{ phpIniOverrides }}:{{ iniLocation }}99-overrides.ini
 {% if mysqlContainerName or postgresContainerName or memcachedContainerName or mailhogContainerName or redisContainerName or elasticsearchContainerName %}{{ "\n" }}
       links:
 {% if memcachedContainerName %}        - memcached{{ "\n" }}{% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/webserver.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/webserver.yml.twig
@@ -3,8 +3,8 @@
       container_name: {{ webserverContainerName }}
       working_dir: /application
       volumes:
-          - ..:/application
-          - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+          - .:/application
+          - ./phpdocker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       ports:
        - "{{ webserverPort }}:80"
       links:

--- a/src/PHPDocker/Zip/Archiver.php
+++ b/src/PHPDocker/Zip/Archiver.php
@@ -56,15 +56,18 @@ class Archiver
      * Adds a file to the list.
      *
      * @param GeneratedFileInterface $generatedFile
+     * @param bool                   $ignorePrefix
      *
      * @return Archiver
      */
-    public function addFile(GeneratedFileInterface $generatedFile): self
+    public function addFile(GeneratedFileInterface $generatedFile, bool $ignorePrefix = false): self
     {
-        $this->zipfile->addFromString(
-            $this->prefixFilename($generatedFile->getFilename()),
-            $generatedFile->getContents()
-        );
+        $localName = $generatedFile->getFilename();
+        if ($ignorePrefix === false) {
+            $localName = $this->prefixFilename($localName);
+        }
+
+        $this->zipfile->addFromString($localName, $generatedFile->getContents());
 
         return $this;
     }


### PR DESCRIPTION
This change is substantial. Having the docker-compose file inside the phpdocker folder was a bit of a PITA because of
  a) `docker-compose exec STUFF` would need you to CD to the folder
  b) container name collisions due to the way docker-compose infers the project name (eg based on the current folder, which would've always been phpdocker)

Remove it out and update the README.