### PR TITLE
set build-context of php-fpm service to phpdocker/php-fpm

### DIFF
--- a/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
@@ -8,9 +8,7 @@
     {% endif %}
 {% endspaceless %}
     php-fpm:
-      build:
-        context: .
-        dockerfile: phpdocker/php-fpm/Dockerfile
+      build: phpdocker/php-fpm
       container_name: {{ phpFpmContainerName }}
       working_dir: /application
       volumes:


### PR DESCRIPTION
As far as I see there are no files copied inside the php docker-container during the build process, so there's no need to set the context to '.' (project-base dir). It would be better to set the build-context to 'phpdocker/php-fpm'.

**Background:**
When you build a container the whole context is copied into the build-process before the build starts, so that files can be copied/added to the container from there. If you have a huge project with some bigger files in it putting them inside the context will slow the build process down by a very noticeable amount of time.
