### PR TITLE
Remove links from services

### DIFF
--- a/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
@@ -14,14 +14,3 @@
       volumes:
         - .:/application
         - ./phpdocker/{{ phpIniOverrides }}:{{ iniLocation }}99-overrides.ini
-{% if mysqlContainerName or postgresContainerName or memcachedContainerName or mailhogContainerName or redisContainerName or elasticsearchContainerName or clickhouseContainerName %}{{ "\n" }}
-      links:
-{% if memcachedContainerName %}        - memcached{{ "\n" }}{% endif %}
-{% if mailhogContainerName %}        - mailhog{{ "\n" }}{% endif %}
-{% if mysqlContainerName %}        - mysql{{ "\n" }}{% endif %}
-{% if mariadbContainerName %}        - mariadb{{ "\n" }}{% endif %}
-{% if postgresContainerName %}        - postgres{{ "\n" }}{% endif %}
-{% if redisContainerName %}        - redis{{ "\n" }}{% endif %}
-{% if elasticsearchContainerName %}        - elasticsearch{{ "\n" }}{% endif %}
-{% if clickhouseContainerName %}        - clickhouse{{ "\n" }}{% endif %}
-{% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/webserver.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/webserver.yml.twig
@@ -7,5 +7,3 @@
           - ./phpdocker/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
       ports:
        - "{{ webserverPort }}:80"
-      links:
-       - php-fpm


### PR DESCRIPTION
Remove links section on php and webserver docker-compose fragments as these are unnecessary now that we don't alias service names