### PR TITLE
expose mysql port to the main container

### DIFF
--- a/src/PHPDocker/Template/docker-compose-fragments/mysql.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/mysql.yml.twig
@@ -10,4 +10,6 @@
         - MYSQL_DATABASE={{ mysql.getDatabaseName() }}
         - MYSQL_USER={{ mysql.getUsername() }}
         - MYSQL_PASSWORD={{ mysql.getPassword() }}
+      ports:
+        - 3306:3306
 {% endif %}


### PR DESCRIPTION
In order to connect to mysql with external tool like sequel or other, we need to expose the mysql port to the main container.

In my case i'm using docker-machine, and i need to get access to the mysql database from my host machine.

```
      ports:
        - 3306:3306
```

adding this line to the docker compose solve my problem.