### PR TITLE
Add mongodb driver to available extensions on php 7.2 and 7.1

### DIFF
--- a/src/PHPDocker/PhpExtension/Php71AvailableExtensions.php
+++ b/src/PHPDocker/PhpExtension/Php71AvailableExtensions.php
@@ -73,6 +73,7 @@ class Php71AvailableExtensions extends BaseAvailableExtensions
             'Intl'        => ['packages' => ['php7.1-intl']],
             'LDAP'        => ['packages' => ['php7.1-ldap']],
             'MBSTRING'    => ['packages' => ['php7.1-mbstring']],
+            'MongoDB'     => ['packages' => ['php-mongodb']],
             'MessagePack' => ['packages' => ['php-msgpack']],
             'ODBC'        => ['packages' => ['php7.1-odbc']],
             'PHPDBG'      => ['packages' => ['php7.1-phpdbg']],

--- a/src/PHPDocker/PhpExtension/Php72AvailableExtensions.php
+++ b/src/PHPDocker/PhpExtension/Php72AvailableExtensions.php
@@ -65,11 +65,13 @@ class Php72AvailableExtensions extends BaseAvailableExtensions
             'GD'          => ['packages' => ['php7.2-gd']],
             'GMP'         => ['packages' => ['php7.2-gmp']],
             'igbinary'    => ['packages' => ['php-igbinary']],
+            'ImageMagick' => ['packages' => ['php-imagick']],
             'IMAP'        => ['packages' => ['php7.2-imap']],
             'Interbase'   => ['packages' => ['php7.2-interbase']],
             'Intl'        => ['packages' => ['php7.2-intl']],
             'LDAP'        => ['packages' => ['php7.2-ldap']],
             'MBSTRING'    => ['packages' => ['php7.2-mbstring']],
+            'MongoDB'     => ['packages' => ['php-mongodb']],
             'MessagePack' => ['packages' => ['php-msgpack']],
             'ODBC'        => ['packages' => ['php7.2-odbc']],
             'PHPDBG'      => ['packages' => ['php7.2-phpdbg']],
@@ -89,11 +91,10 @@ class Php72AvailableExtensions extends BaseAvailableExtensions
 
             // Disabled (not yet on php72 or broken)
 
-            // libgearman broken
+            // libgearman broken (libgearman8 not on repos)
             //            'Gearman'     => ['packages' => ['php-gearman']],
 
             // Still depends on php71 max
-            //            'ImageMagick' => ['packages' => ['php-imagick']],
             //            'Xdebug'      => ['packages' => ['php-xdebug']],
 
             // Installs php56


### PR DESCRIPTION
Also, enable imagick on 7.1

Closes #138.