### PR TITLE
Adjust headlines for GitHub and VSCode

### DIFF
--- a/src/PHPDocker/Template/README.md.twig
+++ b/src/PHPDocker/Template/README.md.twig
@@ -1,7 +1,7 @@
 PHPDocker.io generated environment
 ==================================
 
-#Add to your project#
+# Add to your project #
 
 Simply, unzip the file into your project, this will create `docker-compose.yml` on the root of your project and a folder named `phpdocker` containing nginx and php-fpm config for it.
 
@@ -9,7 +9,7 @@ Ensure the webserver config on `docker\nginx.conf` is correct for your project. 
 
 Note: you may place the files elsewhere in your project. Make sure you modify the locations for the php-fpm dockerfile, the php.ini overrides and nginx config on `docker-compose.yml` if you do so.
  
-#How to run#
+# How to run #
 
 Dependencies:
 
@@ -18,7 +18,7 @@ Dependencies:
 
 Once you're done, simply `cd` to your project and run `docker-compose up -d`. This will initialise and start all the containers, then leave them running in the background.
 
-##Services exposed outside your environment##
+## Services exposed outside your environment ##
 
 You can access your application via **`localhost`**, if you're running the containers directly, or through **`{{ vmIpAddress }}`** when run on a vm. nginx and mailhog both respond to any hostname, in case you want to add your own hostname on your `/etc/hosts` 
 
@@ -29,7 +29,7 @@ Webserver|[localhost:{{ project.getBasePort() }}](http://localhost:{{ project.ge
 {% if project.hasMysql() %}MySQL|**host:** `localhost`; **port:** `{{ project.getBasePort() + 2 }}`{{ "\n" }}{% endif %}
 {% if project.hasMariadb() %}MariaDB|**host:** `localhost`; **port:** `{{ project.getBasePort() + 3 }}`{{ "\n" }}{% endif %}
 
-##Hosts within your environment##
+## Hosts within your environment ##
 
 You'll need to configure your application to use any services you enabled:
 
@@ -45,7 +45,7 @@ php-fpm|php-fpm|9000
 {% if project.hasClickhouse() %}ClickHouse|clickhouse|9000 (HTTP default){{ "\n" }}{% endif %}
 {% if project.hasMailhog() %}SMTP (Mailhog)|mailhog|1025 (default){{ "\n" }}{% endif %}
 
-#Docker compose cheatsheet#
+# Docker compose cheatsheet #
 
 **Note:** you need to cd first to where your docker-compose.yml file lives.
 
@@ -59,7 +59,7 @@ php-fpm|php-fpm|9000
         * Run symfony console, `docker-compose exec php-fpm bin/console`
         * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
 
-#Recommendations#
+# Recommendations #
 
 It's hard to avoid file permission issues when fiddling about with containers due to the fact that, from your OS point of view, any files created within the container are owned by the process that runs the docker engine (this is usually root). Different OS will also have different problems, for instance you can run stuff in containers using `docker exec -it -u $(id -u):$(id -g) CONTAINER_NAME COMMAND` to force your current user ID into the process, but this will only work if your host OS is Linux, not mac. Follow a couple of simple rules and save yourself a world of hurt.
 


### PR DESCRIPTION
The VSCode-Previewer exspects a spaces after # in headlines.
* #Add to your project# results in a normal text: #Add to your project#
* '# Add to your project' # and '# Add to your project' are parsed as headlines.

Githubs advice is nearly similar
* https://help.github.com/articles/basic-writing-and-formatting-syntax/