### PR TITLE
Script up local development bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,18 @@ Running the project
 
 Project is given with a [PHPDocker.io](http://phpdocker.io) generated environment. 
 
+I would recommend you install in your host php cli 7.1+, bower and composer and run the usual steps manually, but it's not necessary - the [`./prepare-dev.sh`](prepare-dev.sh) script will set up the app (bower install, composer install, etc) through docker and docker-compose commands.
+
   * Clone
-  * Copy `app/config/parameters.yml.dist` into `app/config/parameters.yml`
-  * `composer install`
-  * `bower install`
-  * `php bin/console assets:install --symlink --relative`
-  * cd into the project folder and run`docker-compose up -d`. More specific information on [phpdocker/README.md](phpdocker/README.md).
-  * You can then head off to the `/generator` route; you'll need to run `bin/console doctrine:schema:create` within the PHP container (or use the `console` script at the root of the project) to avoid SQL errors on the homepage
+  * Run [`./prepare-dev.sh`](prepare-dev.sh) - this will:
+     * populate default dev config
+     * composer and bower install
+     * clean up caches
+     * ensure web assets are available
+     * load up the database schema (this is just for the CMS side of the website, it has no bearing over the generator)
+     * start up the environment
+  * You can then head off to the [/generator](http://localhost:10000/generator) route.
+
+This is an initial fail-safe set up and not always you need to run it, after it's done once you'll just need to do a good old `docker-compose up -d`. More specific information on [phpdocker/README.md](phpdocker/README.md).
 
 **Note:** you'll notice a `console` script at the root of the project. It does some voodoo to run `bin/console` within the container.

--- a/prepare-dev.sh
+++ b/prepare-dev.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -e
+
+#
+# This script will bootstrap the application for local development use. All the mucking about below around
+# permissions and file ownerships are due to the fact we're running composer, bower etc through docker to avoid
+# requiring from the contributors any dependencies (beyond docker and docker-compose) to be installed on their
+# host system.
+#
+
+bold=$(tput bold)
+normal=$(tput sgr0)
+FIX_OWNERSHIP="sudo chown `id -u`:`id -g` . -Rf"
+PHP_IN_CONTAINER="docker-compose exec php-fpm php "
+
+echo -e "\n${bold} ## Preparing phpdocker.io for local dev ## \n${normal}"
+echo -e "\n In order to fix up symfony cache permissions for both container and host, we'll need to sudo a few commands.\n"
+
+PARAMETERS='app/config/parameters.yml'
+if [[ ! -f ${PARAMETERS} ]]; then
+    echo -e "${bold}parameters.yml file not found, creating...${normal}\n"
+    cp ${PARAMETERS}.dist ${PARAMETERS}
+else
+    echo -e "${bold}parameters.yml file present, leaving alone.${normal}\n"
+fi
+
+# Cleanup
+${FIX_OWNERSHIP}
+
+sudo rm -Rf web/bundles web/css web/js
+sudo rm -Rf var/* -Rf
+rm src/AppBundle/Resources/public/vendor/* -Rf
+
+# Install static assets through bower
+if hash bower 2>/dev/null; then
+    bower install
+else
+    echo -e "\n${bold}Bower not found, running through docker run (much slower)...${normal}\n"
+
+    docker run  \
+        --rm \
+        -it \
+        -v "`pwd`:/workdir" \
+        -w /workdir \
+        node:alpine \
+        sh -c "apk update; apk add git; npm i -g bower; bower install --allow-root"
+
+    ${FIX_OWNERSHIP}
+fi
+
+# Start up environment and run symfony console within container to ensure DB has the schema loaded up
+docker-compose up -d
+
+# Install composer deps
+composer -o install
+
+# Install assets
+mkdir -p web/bundles web/css web/js
+${PHP_IN_CONTAINER} bin/console assets:install --symlink --relative
+
+# Recreate dev cache
+${PHP_IN_CONTAINER} bin/console cache:warmup
+
+# Load up DB schema
+${PHP_IN_CONTAINER} bin/console doctrine:schema:update --force
+
+# Ensure both container and host can write into the var/ folder
+${FIX_OWNERSHIP}
+sudo chmod 777 var/* -Rf
+
+
+
+# Done!
+echo -e "\n${bold} ## Application is now set up ${normal} for localdev, and the environment is up; head off to ${bold}>>> http://localhost:10000 <<< ## \n${normal}"
+


### PR DESCRIPTION
To help up contributors, script up dev-env bootstrap in a manner that does not require any local dependencies beyond docker and docker-compose.

#152 