### PR TITLE
Suppress debconf warnings …

### DIFF
--- a/phpdocker/php-fpm/Dockerfile
+++ b/phpdocker/php-fpm/Dockerfile
@@ -1,4 +1,5 @@
 FROM phpdockerio/php71-fpm:latest
+ARG DEBIAN_FRONTEND=noninteractive
 
 # Install selected extensions and other stuff
 RUN apt-get update \

--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -12,6 +12,9 @@
 FROM {{ image }}
 WORKDIR "/application"
 
+# Fix debconf warnings upon build
+ARG DEBIAN_FRONTEND=noninteractive
+
 {% if extensionPackages %}
 # Install selected extensions and other stuff
 RUN apt-get update \


### PR DESCRIPTION
… by letting it know early it's not running in an interactive shell. 

Closes #159.