### PR TITLE
[prepare-dev.sh] Accommodation for systems without sudo installed.

### DIFF
--- a/prepare-dev.sh
+++ b/prepare-dev.sh
@@ -12,7 +12,7 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 FIX_OWNERSHIP="sudo chown -Rf `id -u`:`id -g` . "
 PHP_IN_CONTAINER="docker-compose exec php-fpm php "
-SUDO_NOT_FOUND="echo -e \n${bold} ## WARNING: The following command requested elevated access but sudo is not installed. ## ${normal}"
+SUDO_NOT_FOUND="\n${bold} ## WARNING: The following command requested elevated access but sudo is not installed. ## ${normal}"
 
 echo -e "\n${bold} ## Preparing phpdocker.io for local dev ## \n${normal}"
 echo -e "\n In order to fix up symfony cache permissions for both container and host, we'll need to sudo a few commands.\n"
@@ -26,7 +26,7 @@ else
 fi
 
 # Address environments that dont have sudo installed (CYGWIN/MINGW/ect)
-hash sudo 2>/dev/null || sudo(){ ${SUDO_NOT_FOUND}; $@; }
+hash sudo 2>/dev/null || sudo(){ echo -e ${SUDO_NOT_FOUND} >&2; $@; }
 
 # Cleanup
 ${FIX_OWNERSHIP}

--- a/prepare-dev.sh
+++ b/prepare-dev.sh
@@ -12,6 +12,7 @@ bold=$(tput bold)
 normal=$(tput sgr0)
 FIX_OWNERSHIP="sudo chown -Rf `id -u`:`id -g` . "
 PHP_IN_CONTAINER="docker-compose exec php-fpm php "
+SUDO_NOT_FOUND="echo -e \n${bold} ## WARNING: The following command requested elevated access but sudo is not installed. ## ${normal}"
 
 echo -e "\n${bold} ## Preparing phpdocker.io for local dev ## \n${normal}"
 echo -e "\n In order to fix up symfony cache permissions for both container and host, we'll need to sudo a few commands.\n"
@@ -25,7 +26,7 @@ else
 fi
 
 # Address environments that dont have sudo installed (CYGWIN/MINGW/ect)
-hash sudo 2>/dev/null || sudo(){ $@; }
+hash sudo 2>/dev/null || sudo(){ ${SUDO_NOT_FOUND}; $@; }
 
 # Cleanup
 ${FIX_OWNERSHIP}

--- a/prepare-dev.sh
+++ b/prepare-dev.sh
@@ -24,6 +24,9 @@ else
     echo -e "${bold}parameters.yml file present, leaving alone.${normal}\n"
 fi
 
+# Address environments that dont have sudo installed (CYGWIN/MINGW/ect)
+hash sudo 2>/dev/null || sudo(){ $@; }
+
 # Cleanup
 ${FIX_OWNERSHIP}
 


### PR DESCRIPTION
I switch between Linux & Windows development environments. The Windows environment uses Git Bash which doesn't include sudo. To address this, This patch adds a check for sudo and maps the command to a function that simply executes the sudo parameters.

Additionally, a warning message is displayed to let the developer know of the command that is being executed without elevation.  This message is sent to stderr to avoid any stdout capture corruption that may occur.

Small, elegant, and gets the job done.

Alternatively, a Windows user could add [imachug/win-sudo](https://github.com/imachug/win-sudo) to the environment to allow for true process elevation but for the sake of this project, that is over kill.