### PR TITLE
nginx.conf path updated

### DIFF
--- a/src/PHPDocker/Template/README.md.twig
+++ b/src/PHPDocker/Template/README.md.twig
@@ -5,7 +5,7 @@ PHPDocker.io generated environment
 
 Simply, unzip the file into your project, this will create `docker-compose.yml` on the root of your project and a folder named `phpdocker` containing nginx and php-fpm config for it.
 
-Ensure the webserver config on `docker\nginx.conf` is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance `web/app|app_dev.php` on a Symfony project, or `public/index.php` on generic apps.
+Ensure the webserver config on `phpdocker/nginx/nginx.conf` is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance `web/app|app_dev.php` on a Symfony project, or `public/index.php` on generic apps.
 
 Note: you may place the files elsewhere in your project. Make sure you modify the locations for the php-fpm dockerfile, the php.ini overrides and nginx config on `docker-compose.yml` if you do so.
  


### PR DESCRIPTION
the nginx.conf path mentioned in README.md does not match the generated contents
this PR fixes this
it also changes "\" to "/" as a separator to match the rest of the file