### PR TITLE
Remove container names

### DIFF
--- a/src/PHPDocker/Generator/Generator.php
+++ b/src/PHPDocker/Generator/Generator.php
@@ -93,7 +93,6 @@ class Generator
         $data = [
             'phpVersion'      => $project->getPhpOptions()->getVersion(),
             'phpIniOverrides' => (new GeneratedFile\PhpIniOverrides(''))->getFilename(),
-            'slug'            => $project->getProjectNameSlug(),
             'project'         => $project,
             'hasClickhouse'   => $project->hasClickhouse(),
         ];
@@ -147,7 +146,6 @@ class Generator
     {
         $data = [
             'projectName'     => $project->getName(),
-            'projectNameSlug' => $project->getProjectNameSlug(),
             'applicationType' => $project->getApplicationOptions()->getApplicationType(),
             'maxUploadSize'   => $project->getApplicationOptions()->getUploadSize(),
         ];

--- a/src/PHPDocker/Template/docker-compose-fragments/elasticsearch.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/elasticsearch.yml.twig
@@ -1,5 +1,4 @@
 {% if project.hasElasticsearch() %}
     elasticsearch:
       image: elasticsearch:{{ elasticsearch.getVersion() }}
-      container_name: {{ slug }}-elasticsearch
 {% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/mailhog.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/mailhog.yml.twig
@@ -1,7 +1,6 @@
 {% if project.hasMailhog() %}
     mailhog:
       image: mailhog/mailhog:latest
-      container_name: {{ slug }}-mailhog
       ports:
         - "{{ project.getBasePort() + 1 }}:8025"
 {% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/mariadb.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/mariadb.yml.twig
@@ -1,7 +1,6 @@
 {% if project.hasMariadb() %}
     mariadb:
       image: mariadb:{{ mariadb.getVersion() }}
-      container_name: {{ slug }}-mariadb
       working_dir: /application
       volumes:
         - .:/application

--- a/src/PHPDocker/Template/docker-compose-fragments/memcached.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/memcached.yml.twig
@@ -1,5 +1,4 @@
 {% if project.hasMemcached() %}
     memcached:
       image: memcached:alpine
-      container_name: {{ slug }}-memcached
 {% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/mysql.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/mysql.yml.twig
@@ -1,7 +1,6 @@
 {% if project.hasMysql() %}
     mysql:
       image: mysql:{{ mysql.getVersion() }}
-      container_name: {{ slug }}-mysql
       working_dir: /application
       volumes:
         - .:/application

--- a/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/php-fpm.yml.twig
@@ -11,7 +11,6 @@
 {% endapply %}
     php-fpm:
       build: phpdocker/php-fpm
-      container_name: {{ slug }}-php-fpm
       working_dir: /application
       volumes:
         - .:/application

--- a/src/PHPDocker/Template/docker-compose-fragments/postgres.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/postgres.yml.twig
@@ -1,7 +1,6 @@
 {% if project.hasPostgres() %}
     postgres:
       image: postgres:{{ postgres.getVersion() }}-alpine
-      container_name: {{ slug }}-postgres
       working_dir: /application
       volumes:
         - .:/application

--- a/src/PHPDocker/Template/docker-compose-fragments/redis.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/redis.yml.twig
@@ -1,5 +1,4 @@
 {% if project.hasRedis() %}
     redis:
       image: redis:alpine
-      container_name: {{ slug }}-redis
 {% endif %}

--- a/src/PHPDocker/Template/docker-compose-fragments/webserver.yml.twig
+++ b/src/PHPDocker/Template/docker-compose-fragments/webserver.yml.twig
@@ -1,6 +1,5 @@
     webserver:
       image: nginx:alpine
-      container_name: {{ slug }}-webserver
       working_dir: /application
       volumes:
           - .:/application


### PR DESCRIPTION
**Changes:**
 * Remove container names - these are not necessary anymore and create unneeded complexity & redundancy
 * Remove generator factory
 * Rely on symfony to do that autowiring from us
 * Remove project name slug from project entity and controller, and pass that responsibility to the generator (needed only for the zip filename now) 