### PR TITLE
Fixed php extension instantiation

### DIFF
--- a/src/PHPDocker/PhpExtension/AvailableExtensionsFactory.php
+++ b/src/PHPDocker/PhpExtension/AvailableExtensionsFactory.php
@@ -52,6 +52,6 @@ class AvailableExtensionsFactory
 
         $className = self::SUPPORTED_VERSIONS[$phpVersion];
 
-        return $className::create();
+        return new $className;
     }
 }


### PR DESCRIPTION
As the other open [issue](https://github.com/phpdocker-io/phpdocker.io/issues/267), I got error 500 after picking PHP extensions, I tried replicating locally the bug and it turned out that on commit https://github.com/phpdocker-io/phpdocker.io/commit/344d42611e454f539804ddaabd14f8629f42f87e#diff-f58dc8200f2030067595ef3f1eaa53697a48360eceabd9d585463404a8217f6a the static method `create` was removed, so the PHP Extension initialization caused the error 500, this should fix it. 