### PR TITLE
Update pagespeed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN apk add git --no-cache; \
     bower install --allow-root
 
 ## Actual deployable frontend image
-FROM pagespeed/nginx-pagespeed:stable AS frontend-deployment
+FROM phpdockerio/nginx-pagespeed:latest AS frontend-deployment
 
 WORKDIR /application
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ HOSTS_LOCATION=bin/hosts
 SITE_HOST=phpdocker.local
 PHP_RUN=docker-compose run -e XDEBUG_MODE=coverage --rm php-fpm
 
-BUILD_TAG?=$(shell date +'%Y-%m-%d-%H-%M-%S')-$(shell git rev-parse --short HEAD)
+BUILD_TAG?:=$(shell date +'%Y-%m-%d-%H-%M-%S')-$(shell git rev-parse --short HEAD)
 
 # linux-amd64, darwin-amd64, linux-arm
 # On windows, override with windows-amd64.exe
@@ -19,6 +19,10 @@ ifndef BUILD_TAG
 endif
 
 echo-build-tag:
+	echo $(BUILD_TAG)
+	sleep 3
+
+echo-build-tag-2:
 	echo $(BUILD_TAG)
 
 start:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
     image: redis:alpine
 
   webserver:
-    image: pagespeed/nginx-pagespeed:stable
+    image: phpdockerio/nginx-pagespeed:latest
     working_dir: /application
     volumes:
       - .:/application

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -13,7 +13,7 @@ server {
 
     client_max_body_size 108M;
 
-    access_log /var/log/nginx/application.access.log;
+    access_log /dev/stdout;
 
     root /application/public;
     index index.php;
@@ -31,7 +31,7 @@ server {
         fastcgi_pass php-fpm:9000;
         fastcgi_index index.php;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PHP_VALUE "error_log=/var/log/nginx/application.error.log";
+        fastcgi_param PHP_VALUE "error_log=/dev/stderr";
         fastcgi_buffers 16 16k;
         fastcgi_buffer_size 32k;
         include fastcgi_params;


### PR DESCRIPTION
The official `pagespeed/nginx-pagespeed` image for nginx with pagespeed seems abandoned. Last build was 3 years ago. 

I've created our own base image for it on our docker hub. This PR switches our localdev and deployment to use it.