### PR TITLE
Switch build to arm and self-hosted kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,14 +62,15 @@ RUN apk add git --no-cache; \
     bower install --allow-root
 
 ## Actual deployable frontend image
-FROM phpdockerio/nginx-pagespeed:latest AS frontend-deployment
+FROM nginx:alpine AS frontend-deployment
+#FROM phpdockerio/nginx-pagespeed:latest AS frontend-deployment
 
 WORKDIR /application
 
 RUN mkdir ./web; \
     touch ./web/app.php
 
-COPY infrastructure/nginx/pagespeed.conf /etc/nginx/pagespeed.conf
+#COPY infrastructure/nginx/pagespeed.conf /etc/nginx/pagespeed.conf
 COPY infrastructure/nginx/nginx.conf /etc/nginx/conf.d/default.conf
 
 # NGINX config: update php-fpm hostname to localhost (same pod in k8s), activate pagespeed config, deactivate SSL

--- a/Makefile
+++ b/Makefile
@@ -119,20 +119,9 @@ open-coverage-report:
 	xdg-open reports/phpunit/index.html
 
 ### Deployment targets
-
-build-images:
-	docker build --pull --target=backend-deployment  -t phpdocker-old-php-fpm .
-	docker build --pull --target=frontend-deployment -t phpdocker-old-nginx   .
-
-tag-images:
-	docker tag phpdocker-old-nginx eu.gcr.io/auron-infrastructure/phpdocker-old-nginx:$(BUILD_TAG)
-	docker tag phpdocker-old-php-fpm eu.gcr.io/auron-infrastructure/phpdocker-old-php-fpm:$(BUILD_TAG)
-
-push-images:
-	docker push eu.gcr.io/auron-infrastructure/phpdocker-old-nginx:$(BUILD_TAG)
-	docker push eu.gcr.io/auron-infrastructure/phpdocker-old-php-fpm:$(BUILD_TAG)
-
-build-and-push: build-images tag-images push-images
+build-and-push:
+	docker buildx build --target=backend-deployment  --tag eu.gcr.io/auron-infrastructure/phpdocker-old-php-fpm:$(BUILD_TAG) --platform linux/arm/v7 --pull --push .
+	docker buildx build --target=frontend-deployment --tag eu.gcr.io/auron-infrastructure/phpdocker-old-nginx:$(BUILD_TAG)   --platform linux/arm/v7 --pull --push .
 
 deploy:
 	cp infrastructure/kubernetes/deployment.yaml /tmp/phpdocker-deployment-$(BUILD_TAG).yaml

--- a/Makefile
+++ b/Makefile
@@ -120,8 +120,8 @@ open-coverage-report:
 
 ### Deployment targets
 build-and-push:
-	docker buildx build --target=backend-deployment  --tag eu.gcr.io/auron-infrastructure/phpdocker-old-php-fpm:$(BUILD_TAG) --platform linux/arm/v7 --pull --push .
-	docker buildx build --target=frontend-deployment --tag eu.gcr.io/auron-infrastructure/phpdocker-old-nginx:$(BUILD_TAG)   --platform linux/arm/v7 --pull --push .
+	docker buildx build --target=backend-deployment  --tag eu.gcr.io/auron-infrastructure/phpdocker-php-fpm:$(BUILD_TAG) --platform linux/arm/v7 --pull --push .
+	docker buildx build --target=frontend-deployment --tag eu.gcr.io/auron-infrastructure/phpdocker-nginx:$(BUILD_TAG)   --platform linux/arm/v7 --pull --push .
 
 deploy:
 	cp infrastructure/kubernetes/deployment.yaml /tmp/phpdocker-deployment-$(BUILD_TAG).yaml

--- a/infrastructure/kubernetes/deployment.yaml
+++ b/infrastructure/kubernetes/deployment.yaml
@@ -55,8 +55,6 @@ spec:
       labels:
         app: phpdocker-io-old
     spec:
-      nodeSelector:
-        preemptible: "false"
       containers:
         - image: eu.gcr.io/auron-infrastructure/phpdocker-old-nginx:latest
           name: nginx
@@ -133,8 +131,6 @@ spec:
       labels:
         app: redis
     spec:
-      nodeSelector:
-        preemptible: "false"
       containers:
         - image: redis:alpine
           name: redis

--- a/infrastructure/kubernetes/deployment.yaml
+++ b/infrastructure/kubernetes/deployment.yaml
@@ -63,7 +63,7 @@ metadata:
   labels:
     app: phpdocker
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
   selector:

--- a/infrastructure/kubernetes/deployment.yaml
+++ b/infrastructure/kubernetes/deployment.yaml
@@ -29,10 +29,14 @@ kind: Ingress
 metadata:
   name: phpdocker
   namespace: phpdocker
+  annotations:
+    nginx.ingress.kubernetes.io/server-alias: www.phpdocker.io
+    cert-manager.io/cluster-issuer: letsencrypt-prod
 spec:
   ingressClassName: nginx
   rules:
-    - http:
+    - host: phpdocker.io
+      http:
         paths:
           - path: /
             pathType: Prefix
@@ -41,6 +45,11 @@ spec:
                 name: phpdocker
                 port:
                   number: 80
+  tls:
+    - secretName: phpdocker-tls
+      hosts:
+        - phpdocker.io
+        - www.phpdocker.io
 
 ---
 

--- a/infrastructure/kubernetes/deployment.yaml
+++ b/infrastructure/kubernetes/deployment.yaml
@@ -2,34 +2,53 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: phpdocker-io-old
+  name: phpdocker
   labels:
-    name: phpdocker-io-old
+    name: phpdocker
 
 ---
 
 apiVersion: v1
 kind: Service
 metadata:
-  name: phpdocker-io-old
-  namespace: phpdocker-io-old
+  name: phpdocker
+  namespace: phpdocker
   labels:
-    app: phpdocker-io-old
+    app: phpdocker
 spec:
   ports:
     - port: 80
       targetPort: 80
       protocol: TCP
   selector:
-    app: phpdocker-io-old
+    app: phpdocker
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: phpdocker
+  namespace: phpdocker
+spec:
+  ingressClassName: nginx
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: phpdocker
+                port:
+                  number: 80
 
 ---
 
 kind: ConfigMap
 apiVersion: v1
 metadata:
-  name: phpdocker-io-old
-  namespace: phpdocker-io-old
+  name: phpdocker
+  namespace: phpdocker
 data:
   redis_host: "redis"
   redis_port: "6379"
@@ -39,27 +58,27 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: phpdocker-io-old
-  namespace: phpdocker-io-old
+  name: phpdocker
+  namespace: phpdocker
   labels:
-    app: phpdocker-io-old
+    app: phpdocker
 spec:
   replicas: 2
   strategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: phpdocker-io-old
+      app: phpdocker
   template:
     metadata:
       labels:
-        app: phpdocker-io-old
+        app: phpdocker
     spec:
       containers:
-        - image: eu.gcr.io/auron-infrastructure/phpdocker-old-nginx:latest
+        - image: eu.gcr.io/auron-infrastructure/phpdocker-nginx:latest
           name: nginx
 
-        - image: eu.gcr.io/auron-infrastructure/phpdocker-old-php-fpm:latest
+        - image: eu.gcr.io/auron-infrastructure/phpdocker-php-fpm:latest
           name: php-fpm
 
           env:
@@ -72,25 +91,25 @@ spec:
             - name: APP_SECRET
               valueFrom:
                 secretKeyRef:
-                  name: phpdocker-io-old
+                  name: phpdocker
                   key: app.secret
 
             - name: GOOGLE_ANALYTICS
               valueFrom:
                 secretKeyRef:
-                  name: phpdocker-io-old
+                  name: phpdocker
                   key: google_analytics
 
             - name: REDIS_HOST
               valueFrom:
                 configMapKeyRef:
-                  name: phpdocker-io-old
+                  name: phpdocker
                   key: redis_host
 
             - name: REDIS_PORT
               valueFrom:
                 configMapKeyRef:
-                  name: phpdocker-io-old
+                  name: phpdocker
                   key: redis_port
 
 ---
@@ -99,7 +118,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: redis
-  namespace: phpdocker-io-old
+  namespace: phpdocker
   labels:
     app: redis
 spec:
@@ -116,7 +135,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis
-  namespace: phpdocker-io-old
+  namespace: phpdocker
   labels:
     app: redis
 spec:

--- a/infrastructure/nginx/nginx.conf
+++ b/infrastructure/nginx/nginx.conf
@@ -38,5 +38,5 @@ server {
     }
 
     # Pagespeed config
-    # %DEPLOYMENT include /etc/nginx/pagespeed.conf;
+    # %DISABLED DEPLOYMENT include /etc/nginx/pagespeed.conf;
 }


### PR DESCRIPTION
I'm migrating away from GKE to self hosted Kubernetes on Raspberry pi. This PR tweaks build & deployment to make it compatible
with 32 bit arm.

**Changes:**

 * Switch to buildx and build on linux/arm/7 (32 bit)
 * Switch back to nginx (from nginx-pagespeed) as there's no arm support for pagespeed-ngx
 * Clean up Makefile of separate docker commands - can now build, tag and push in one go
 * Remove node selectors
 * Deploy against self-hosted kubernetes
 * Add nginx ingress with let's encrypt ssl certs
 * Change k8s namespace to `phpdocker`