### PR TITLE
Use the new php image registry format

### DIFF
--- a/public/js/main-form.js
+++ b/public/js/main-form.js
@@ -103,15 +103,15 @@ function doMainFormMagic () {
         extensionMultiSelects.parents('.form-group').hide()
 
         switch ($(this).val()) {
-            case '7.2.x':
+            case '7.2':
                 extensionMultiSelects.filter('[id$=72]').parents('.form-group').show()
                 break
 
-            case '7.3.x':
+            case '7.3':
                 extensionMultiSelects.filter('[id$=73]').parents('.form-group').show()
                 break
 
-            case '7.4.x':
+            case '7.4':
                 extensionMultiSelects.filter('[id$=74]').parents('.form-group').show()
                 break
 

--- a/src/Form/Generator/PhpType.php
+++ b/src/Form/Generator/PhpType.php
@@ -69,28 +69,28 @@ class PhpType extends AbstractGeneratorType
             ->add('phpExtensions72', ChoiceType::class, [
                 'choices'     => $this->getExtensionChoices((new Php72AvailableExtensions())->getOptional()),
                 'multiple'    => true,
-                'label'       => 'Extensions (PHP 7.2.x)',
+                'label'       => 'Extensions (PHP 7.2)',
                 'required'    => false,
                 'constraints' => $phpOptionsConstraints,
             ])
             ->add('phpExtensions73', ChoiceType::class, [
                 'choices'     => $this->getExtensionChoices((new Php73AvailableExtensions())->getOptional()),
                 'multiple'    => true,
-                'label'       => 'Extensions (PHP 7.3.x)',
+                'label'       => 'Extensions (PHP 7.3)',
                 'required'    => false,
                 'constraints' => $phpOptionsConstraints,
             ])
             ->add('phpExtensions74', ChoiceType::class, [
                 'choices'     => $this->getExtensionChoices((new Php74AvailableExtensions())->getOptional()),
                 'multiple'    => true,
-                'label'       => 'Extensions (PHP 7.4.x)',
+                'label'       => 'Extensions (PHP 7.4)',
                 'required'    => false,
                 'constraints' => $phpOptionsConstraints,
             ])
             ->add('phpExtensions80', ChoiceType::class, [
                 'choices'     => $this->getExtensionChoices((new Php80AvailableExtensions())->getOptional()),
                 'multiple'    => true,
-                'label'       => 'Extensions (PHP 8.0.x)',
+                'label'       => 'Extensions (PHP 8.0)',
                 'required'    => false,
                 'constraints' => $phpOptionsConstraints,
             ]);

--- a/src/PHPDocker/PhpExtension/AvailableExtensionsFactory.php
+++ b/src/PHPDocker/PhpExtension/AvailableExtensionsFactory.php
@@ -26,10 +26,10 @@ use InvalidArgumentException;
  */
 class AvailableExtensionsFactory
 {
-    private const PHP_VERSION_72 = '7.2.x';
-    private const PHP_VERSION_73 = '7.3.x';
-    private const PHP_VERSION_74 = '7.4.x';
-    private const PHP_VERSION_80 = '8.0.x';
+    private const PHP_VERSION_72 = '7.2';
+    private const PHP_VERSION_73 = '7.3';
+    private const PHP_VERSION_74 = '7.4';
+    private const PHP_VERSION_80 = '8.0';
 
     /**
      * Supported PHP versions

--- a/src/PHPDocker/Project/ServiceOptions/MySQL.php
+++ b/src/PHPDocker/Project/ServiceOptions/MySQL.php
@@ -32,7 +32,7 @@ class MySQL extends AbstractMySQL
     private const VERSION_80 = '8.0';
 
     private const ALLOWED_VERSIONS = [
-        self::VERSION_80 => '8.0.x',
+        self::VERSION_80 => '8.0',
         self::VERSION_57 => '5.7.x',
         self::VERSION_56 => '5.6.x',
         self::VERSION_55 => '5.5.x',

--- a/src/PHPDocker/Project/ServiceOptions/Php.php
+++ b/src/PHPDocker/Project/ServiceOptions/Php.php
@@ -28,10 +28,10 @@ use InvalidArgumentException;
  */
 class Php extends Base
 {
-    public const PHP_VERSION_72 = '7.2.x';
-    public const PHP_VERSION_73 = '7.3.x';
-    public const PHP_VERSION_74 = '7.4.x';
-    public const PHP_VERSION_80 = '8.0.x';
+    public const PHP_VERSION_72 = '7.2';
+    public const PHP_VERSION_73 = '7.3';
+    public const PHP_VERSION_74 = '7.4';
+    public const PHP_VERSION_80 = '8.0';
 
     private string $version;
 

--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -1,15 +1,4 @@
-{% apply spaceless %}
-    {% if phpVersion == '7.2' %}
-        {% set image = 'phpdockerio/php72-fpm:latest' %}
-    {% elseif phpVersion == '7.3' %}
-        {% set image = 'phpdockerio/php73-fpm:latest' %}
-    {% elseif phpVersion == '7.4' %}
-        {% set image = 'phpdockerio/php74-fpm:latest' %}
-    {% else %}
-        {% set image = 'phpdockerio/php80-fpm:latest' %}
-    {% endif %}
-{% endapply %}
-FROM {{ image }}
+FROM 'phpdockerio/php:{{ phpVersion }}-fpm'
 WORKDIR "{{ dockerWorkingDir }}"
 
 {% if packages %}

--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -1,9 +1,9 @@
 {% apply spaceless %}
-    {% if phpVersion == '7.2.x' %}
+    {% if phpVersion == '7.2' %}
         {% set image = 'phpdockerio/php72-fpm:latest' %}
-    {% elseif phpVersion == '7.3.x' %}
+    {% elseif phpVersion == '7.3' %}
         {% set image = 'phpdockerio/php73-fpm:latest' %}
-    {% elseif phpVersion == '7.4.x' %}
+    {% elseif phpVersion == '7.4' %}
         {% set image = 'phpdockerio/php74-fpm:latest' %}
     {% else %}
         {% set image = 'phpdockerio/php80-fpm:latest' %}


### PR DESCRIPTION
Container images for PHP are now built all into the same container registry endpoint: `phpdockerio/php` and differentiated by version tags, eg `phpdockerio/php:8.0-fpm`.

**Changes:**

 * Refer to php versions internally as MAJOR.MINOR -> 8.0 instead of 8.0.x
 * Tweak Dockerfile generator to reflect new image repositories
