### PR TITLE
Refactor external ports

### DIFF
--- a/src/PHPDocker/Project/ServiceOptions/Base.php
+++ b/src/PHPDocker/Project/ServiceOptions/Base.php
@@ -23,9 +23,6 @@ namespace App\PHPDocker\Project\ServiceOptions;
  */
 abstract class Base
 {
-    /**
-     * @var bool
-     */
     protected bool $enabled = false;
 
     public function isEnabled(): bool
@@ -38,5 +35,25 @@ abstract class Base
         $this->enabled = $enabled;
 
         return $this;
+    }
+
+    /**
+     * Return this service's external (meaning bound into the host from docker) port as a function of a given base
+     * port plus our internal offset.
+     */
+    public function getExternalPort(int $basePort): ?int
+    {
+        $offset = $this->getExternalPortOffset();
+
+        return $offset ?? $basePort + $offset;
+    }
+
+    /**
+     * When calculating our external port, we add this offset to a given base port.
+     *
+     * Override downstream for services you want them to have an external port.
+     */
+    protected function getExternalPortOffset(): ?int
+    {
     }
 }

--- a/src/PHPDocker/Project/ServiceOptions/Base.php
+++ b/src/PHPDocker/Project/ServiceOptions/Base.php
@@ -55,5 +55,6 @@ abstract class Base
      */
     protected function getExternalPortOffset(): ?int
     {
+        return null;
     }
 }

--- a/src/PHPDocker/Project/ServiceOptions/Base.php
+++ b/src/PHPDocker/Project/ServiceOptions/Base.php
@@ -45,7 +45,7 @@ abstract class Base
     {
         $offset = $this->getExternalPortOffset();
 
-        return $offset ?? $basePort + $offset;
+        return $offset !== null ? ($basePort + $offset) : null;
     }
 
     /**

--- a/src/PHPDocker/Project/ServiceOptions/Mailhog.php
+++ b/src/PHPDocker/Project/ServiceOptions/Mailhog.php
@@ -23,4 +23,8 @@ namespace App\PHPDocker\Project\ServiceOptions;
  */
 class Mailhog extends Base
 {
+    protected function getExternalPortOffset(): ?int
+    {
+        return 1;
+    }
 }

--- a/src/PHPDocker/Project/ServiceOptions/MariaDB.php
+++ b/src/PHPDocker/Project/ServiceOptions/MariaDB.php
@@ -54,6 +54,11 @@ class MariaDB extends AbstractMySQL
         $this->version = self::VERSION_106;
     }
 
+    protected function getExternalPortOffset(): ?int
+    {
+        return 3;
+    }
+
     /**
      * @inheritdoc
      * @return array<string, string>

--- a/src/PHPDocker/Project/ServiceOptions/MySQL.php
+++ b/src/PHPDocker/Project/ServiceOptions/MySQL.php
@@ -43,6 +43,11 @@ class MySQL extends AbstractMySQL
         $this->version = self::VERSION_80;
     }
 
+    protected function getExternalPortOffset(): ?int
+    {
+        return 2;
+    }
+
     /**
      * @inheritdoc
      * @return array<string, string>

--- a/src/PHPDocker/Project/ServiceOptions/Postgres.php
+++ b/src/PHPDocker/Project/ServiceOptions/Postgres.php
@@ -62,6 +62,11 @@ class Postgres extends Base
     private string $rootPassword;
     private string $databaseName;
 
+    protected function getExternalPortOffset(): ?int
+    {
+        return 4;
+    }
+
     public function getVersion(): string
     {
         return $this->version;

--- a/src/PHPDocker/Template/README.md.twig
+++ b/src/PHPDocker/Template/README.md.twig
@@ -8,13 +8,12 @@ Simply, unzip the file into your project, this will create `docker-compose.yml` 
 Ensure the webserver config on `phpdocker/nginx/nginx.conf` is correct for your project. PHPDocker.io will have customised this file according to the application type you chose on the generator, for instance `web/app|app_dev.php` on a Symfony project, or `public/index.php` on generic apps.
 
 Note: you may place the files elsewhere in your project. Make sure you modify the locations for the php-fpm dockerfile, the php.ini overrides and nginx config on `docker-compose.yml` if you do so.
- 
+
 # How to run #
 
 Dependencies:
-
-  * Docker engine v1.13 or higher. Your OS provided package might be a little old, if you encounter problems, do upgrade. See [https://docs.docker.com/engine/installation](https://docs.docker.com/engine/installation)
-  * Docker compose v1.12 or higher. See [docs.docker.com/compose/install](https://docs.docker.com/compose/install/)
+  * Docker. See [https://docs.docker.com/engine/installation](https://docs.docker.com/engine/installation)
+  * Docker compose. See [docs.docker.com/compose/install](https://docs.docker.com/compose/install/)
 
 Once you're done, simply `cd` to your project and run `docker-compose up -d`. This will initialise and start all the containers, then leave them running in the background.
 
@@ -22,12 +21,14 @@ Once you're done, simply `cd` to your project and run `docker-compose up -d`. Th
 
 You can access your application via **`localhost`**. Mailhog and nginx both respond to any hostname, in case you want to add your own hostname on your `/etc/hosts`
 
+{% set basePort = project.getBasePort() %}
 Service|Address outside containers
-------|---------|-----------
-Webserver|[localhost:{{ project.getBasePort() }}](http://localhost:{{ project.getBasePort() }})
-{% if project.hasMailhog() %}Mailhog web interface|[localhost:{{ project.getBasePort() + 1 }}](http://localhost:{{ project.getBasePort() + 1 }}){{ "\n" }}{% endif %}
-{% if project.hasMysql() %}MySQL|**host:** `localhost`; **port:** `{{ project.getBasePort() + 2 }}`{{ "\n" }}{% endif %}
-{% if project.hasMariadb() %}MariaDB|**host:** `localhost`; **port:** `{{ project.getBasePort() + 3 }}`{{ "\n" }}{% endif %}
+-------|--------------------------
+Webserver|[localhost:{{ basePort }}](http://localhost:{{ basePort }})
+{% if project.hasMailhog() %}Mailhog web interface|[localhost:{{ project.getMailhogOptions().getExternalPort(basePort) }}](http://localhost:{{ project.getMailhogOptions().getExternalPort(basePort) }}){{ "\n" }}{% endif %}
+{% if project.hasMysql() %}MySQL|**host:** `localhost`; **port:** `{{ project.getMysqlOptions().getExternalPort(basePort) }}`{{ "\n" }}{% endif %}
+{% if project.hasMariadb() %}MariaDB|**host:** `localhost`; **port:** `{{ project.getMariadbOptions().getExternalPort(basePort) }}`{{ "\n" }}{% endif %}
+{% if project.hasPostgres() %}PostgreSQL|**host:** `localhost`; **port:** `{{ project.getPostgresOptions().getExternalPort(basePort) }}`{{ "\n" }}{% endif %}
 
 ## Hosts within your environment ##
 
@@ -50,14 +51,14 @@ php-fpm|php-fpm|9000
 **Note:** you need to cd first to where your docker-compose.yml file lives.
 
   * Start containers in the background: `docker-compose up -d`
-  * Start containers on the foreground: `docker-compose up`. You will see a stream of logs for every container running.
+  * Start containers on the foreground: `docker-compose up`. You will see a stream of logs for every container running. ctrl+c stops containers.
   * Stop containers: `docker-compose stop`
   * Kill containers: `docker-compose kill`
-  * View container logs: `docker-compose logs`
+  * View container logs: `docker-compose logs` for all containers or `docker-compose logs SERVICE_NAME` for the logs of all containers in `SERVICE_NAME`.
   * Execute command inside of container: `docker-compose exec SERVICE_NAME COMMAND` where `COMMAND` is whatever you want to run. Examples:
-        * Shell into the PHP container, `docker-compose exec php-fpm bash`
-        * Run symfony console, `docker-compose exec php-fpm bin/console`
-        * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
+    * Shell into the PHP container, `docker-compose exec php-fpm bash`
+    * Run symfony console, `docker-compose exec php-fpm bin/console`
+    * Open a mysql shell, `docker-compose exec mysql mysql -uroot -pCHOSEN_ROOT_PASSWORD`
 
 # Application file permissions #
 


### PR DESCRIPTION
In order to calculate the external port to a service we always added a sequential offset to the base port. This worked but resulted in discrepancies between the README and the reality of the docker-compose setup as the looping logic wasn't the same.

This PR tweaks the ServiceOptions objects to make them capable of expressing their external port, given the base port. Then we use this facility on the generation of the README and docker-compose.

Closes #277 