### PR TITLE
Fix dodgy use of static when calculating available extensions for a given version of PHP

### DIFF
--- a/src/PHPDocker/PhpExtension/BaseAvailableExtensions.php
+++ b/src/PHPDocker/PhpExtension/BaseAvailableExtensions.php
@@ -23,6 +23,9 @@ namespace App\PHPDocker\PhpExtension;
  */
 abstract class BaseAvailableExtensions
 {
+    /** @var array<string, array<string, string[]>> */
+    private array $allExtensions = [];
+
     /**
      * Must return an array of all available mandatory extensions, indexed by display name
      * and containing an array of ['packages' => ['deb-package-1', 'deb-package-2' ...]
@@ -54,13 +57,11 @@ abstract class BaseAvailableExtensions
      */
     public function getAll(): array
     {
-        static $allExtensions;
-
-        if ($allExtensions === null) {
-            $allExtensions = array_merge($this->getMandatoryExtensionsMap(), $this->getOptionalExtensionsMap());
+        if ($this->allExtensions === []) {
+            $this->allExtensions = array_merge($this->getMandatoryExtensionsMap(), $this->getOptionalExtensionsMap());
         }
 
-        return $allExtensions;
+        return $this->allExtensions;
     }
 
     /**


### PR DESCRIPTION
This will break in php 8.1