### PR TITLE
Re-do routes

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -1,12 +1,12 @@
 
 home:
-  path: /
+  path: /generator
   controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
   defaults:
-    path: /generator
+    path: /
     permanent: true
 
 generator:
-  path: /generator
+  path: /
   controller: App\Controller\GeneratorController::create
   methods: [GET, POST]

--- a/features/generator.feature
+++ b/features/generator.feature
@@ -2,28 +2,28 @@ Feature:
   Generator tests
 
   Scenario: Home page redirects to generator
-    When I load "/"
-    Then it should permanently redirect to "http://localhost/generator"
+    When I load "/generator"
+    Then it should permanently redirect to "http://localhost/"
 
   Scenario: Generator page loads correctly
-    When I load "/generator"
+    When I load "/"
     Then the response code should be 200
 
   Scenario: Generator requires a base port
-    Given I am on "/generator"
+    Given I am on "/"
     And I fill in "project_globalOptions_basePort" with ""
     And I press "Generate project archive"
     Then the "#container_for_basePort" element should contain "This value should not be blank."
 
   Scenario: Generate a project only with default settings
-    Given I am on "/generator"
+    Given I am on "/"
     When I press "Generate project archive"
     Then the response code should be 200
     And I should receive a zip file named "phpdocker.zip"
 #    And show last response
 
   Scenario: Check MySQL validation works
-    Given I am on "/generator"
+    Given I am on "/"
     When I check "Enable MySQL"
     And I press "Generate project archive"
     Then the "#container_for_mysql_rootPassword" element should contain "This value should not be blank."
@@ -32,7 +32,7 @@ Feature:
     And the "#container_for_mysql_password" element should contain "This value should not be blank."
 
   Scenario: MySQL config works correctly
-    Given I am on "/generator"
+    Given I am on "/"
     When I check "Enable MySQL"
     And I fill in "project_mysqlOptions_rootPassword" with "root pass"
     And I fill in "project_mysqlOptions_databaseName" with "db name"

--- a/tests/Functional/GeneratorTest.php
+++ b/tests/Functional/GeneratorTest.php
@@ -39,11 +39,11 @@ class GeneratorTest extends WebTestCase
     /**
      * @test
      */
-    public function homeRedirectsToGenerator(): void
+    public function generatorRedirectsToHome(): void
     {
-        $this->client->request(method: 'GET', uri: '/');
+        $this->client->request(method: 'GET', uri: '/generator');
 
-        self::assertResponseRedirects(expectedLocation: 'http://localhost/generator', expectedCode: 301);
+        self::assertResponseRedirects(expectedLocation: 'http://localhost/', expectedCode: 301);
     }
 
     /**
@@ -51,7 +51,7 @@ class GeneratorTest extends WebTestCase
      */
     public function generatorLoads(): void
     {
-        $this->client->request(method: 'GET', uri: '/generator');
+        $this->client->request(method: 'GET', uri: '/');
 
         self::assertResponseIsSuccessful();
     }


### PR DESCRIPTION
Changes:
 * `/generator` is now `/`
 * Ensure `/generator` redirects to `/`
 * Tweak required test expectations