### PR TITLE
Use xdebug.client_host for Xdebug 3 on Windows

### DIFF
--- a/src/PHPDocker/Template/README.md.twig
+++ b/src/PHPDocker/Template/README.md.twig
@@ -129,7 +129,7 @@ xdebug.start_with_request = yes
 
 ```
 xdebug.mode = debug
-xdebug.remote_host = host.docker.internal
+xdebug.client_host = host.docker.internal
 xdebug.start_with_request = yes
 ```
 


### PR DESCRIPTION
I realized the documentation still mentions an old setting from Xdebug 2 on the Xdebug 3 instructions.
I changed that on my WSL setup and got Xdebug to work; I've no idea if it also applies to MacOS.

Reference: https://xdebug.org/docs/upgrade_guide#changed-xdebug.remote_host