### PR TITLE
ErrorException: Warning: Object of class Monolog\Level could not be converted to int

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "symfony/validator": "^6.0",
         "symfony/yaml": "^6.0",
         "twig/extra-bundle": "^3.0",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.0",
+        "monolog/monolog": "2.9.1"
     },
     "require-dev": {
         "beberlei/assert": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d311a4e99f882a267dcac9500e0eb72",
+    "content-hash": "96000995f2d54ee25eaf696dcf22bc3d",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -258,41 +258,42 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "3.2.0",
+            "version": "2.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "305444bc6fb6c89e490f4b34fa6e979584d7fa81"
+                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/305444bc6fb6c89e490f4b34fa6e979584d7fa81",
-                "reference": "305444bc6fb6c89e490f4b34fa6e979584d7fa81",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
+                "reference": "f259e2b15fb95494c83f52d3caad003bbf5ffaa1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "psr/log": "^2.0 || ^3.0"
+                "php": ">=7.2",
+                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "3.0.0"
+                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^3.0",
+                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2",
+                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
                 "guzzlehttp/guzzle": "^7.4",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-deprecation-rules": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.1",
-                "phpunit/phpunit": "^9.5.16",
-                "predis/predis": "^1.1",
+                "phpspec/prophecy": "^1.15",
+                "phpstan/phpstan": "^0.12.91",
+                "phpunit/phpunit": "^8.5.14",
+                "predis/predis": "^1.1 || ^2.0",
+                "rollbar/rollbar": "^1.3 || ^2 || ^3",
                 "ruflin/elastica": "^7",
+                "swiftmailer/swiftmailer": "^5.3|^6.0",
                 "symfony/mailer": "^5.4 || ^6",
                 "symfony/mime": "^5.4 || ^6"
             },
@@ -315,7 +316,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.x-dev"
+                    "dev-main": "2.x-dev"
                 }
             },
             "autoload": {
@@ -343,7 +344,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/3.2.0"
+                "source": "https://github.com/Seldaek/monolog/tree/2.9.1"
             },
             "funding": [
                 {
@@ -355,7 +356,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-24T12:00:55+00:00"
+            "time": "2023-02-06T13:44:46+00:00"
         },
         {
             "name": "psr/cache",


### PR DESCRIPTION
Hi! I am trying to use the public service but is down. Also, my local environment did not work. I think that the most recent **monolog** version has a problem. In my local environment I fixed this error downgrading the monolog package to 2.9.1. Perhaps, the public service has the same problem.

This is the error:

```php
ErrorException:
Warning: Object of class Monolog\Level could not be converted to int

at /application/vendor/monolog/monolog/src/Monolog/Logger.php:321
at Monolog\Logger->addRecord()
(/application/vendor/monolog/monolog/src/Monolog/Logger.php:580)
at Monolog\Logger->debug()
(/application/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:285)
at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->postProcess()
(/application/vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:138)
at Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher->dispatch()
(/application/vendor/symfony/http-kernel/HttpKernel.php:221)
at Symfony\Component\HttpKernel\HttpKernel->handleThrowable()
(/application/vendor/symfony/http-kernel/HttpKernel.php:114)
at Symfony\Component\HttpKernel\HttpKernel->terminateWithException()
(/application/vendor/symfony/http-kernel/EventListener/DebugHandlersListener.php:125)
at Symfony\Component\HttpKernel\EventListener\DebugHandlersListener::Symfony\Component\HttpKernel\EventListener\{closure}()
(/application/vendor/symfony/error-handler/ErrorHandler.php:538)
at Symfony\Component\ErrorHandler\ErrorHandler->handleException()                
```

I think this issue is related to [monolog 1789](https://github.com/Seldaek/monolog/issues/1789).