### PR TITLE
Inspection fixes: readonly properties

### DIFF
--- a/src/Assert/PostgresTypeValidator.php
+++ b/src/Assert/PostgresTypeValidator.php
@@ -32,7 +32,7 @@ class PostgresTypeValidator extends ConstraintValidator
      */
     public function validate(mixed $value, Constraint|PostgresType $constraint): void
     {
-        if ($value !== null && is_string($value) && array_key_exists($value, Postgres::getChoices()) === false) {
+        if (is_string($value) && array_key_exists($value, Postgres::getChoices()) === false) {
             $this
                 ->context
                 ->buildViolation($constraint->message)

--- a/src/Controller/GeneratorController.php
+++ b/src/Controller/GeneratorController.php
@@ -35,7 +35,7 @@ use Symfony\Component\HttpFoundation\ResponseHeaderBag;
  */
 class GeneratorController extends AbstractController
 {
-    public function __construct(private Generator $generator)
+    public function __construct(private readonly Generator $generator)
     {
     }
 

--- a/src/PHPDocker/Generator/Files/DockerCompose.php
+++ b/src/PHPDocker/Generator/Files/DockerCompose.php
@@ -32,7 +32,7 @@ class DockerCompose implements GeneratedFileInterface
     private string $defaultVolume;
     private int    $basePort;
 
-    public function __construct(private Dumper $yaml, private Project $project, private string $phpIniLocation)
+    public function __construct(private readonly Dumper $yaml, private readonly Project $project, private readonly string $phpIniLocation)
     {
         $this->basePort = $this->project->getGlobalOptions()->getBasePort();
     }

--- a/src/PHPDocker/Generator/Files/Dockerfile.php
+++ b/src/PHPDocker/Generator/Files/Dockerfile.php
@@ -27,7 +27,7 @@ class Dockerfile implements GeneratedFileInterface
 {
     private const FILENAME = 'php-fpm' . DIRECTORY_SEPARATOR . 'Dockerfile';
 
-    public function __construct(private Environment $twig, private Project $project)
+    public function __construct(private readonly Environment $twig, private readonly Project $project)
     {
     }
 

--- a/src/PHPDocker/Generator/Files/NginxConf.php
+++ b/src/PHPDocker/Generator/Files/NginxConf.php
@@ -25,7 +25,7 @@ use Twig\Environment;
 
 class NginxConf implements GeneratedFileInterface
 {
-    public function __construct(private Environment $twig, private Project $project)
+    public function __construct(private readonly Environment $twig, private readonly Project $project)
     {
     }
 

--- a/src/PHPDocker/Generator/Files/PhpIni.php
+++ b/src/PHPDocker/Generator/Files/PhpIni.php
@@ -26,7 +26,7 @@ use Twig\Environment;
 class PhpIni implements GeneratedFileInterface
 {
 
-    public function __construct(private Environment $twig)
+    public function __construct(private readonly Environment $twig)
     {
     }
 

--- a/src/PHPDocker/Generator/Files/ReadmeHtml.php
+++ b/src/PHPDocker/Generator/Files/ReadmeHtml.php
@@ -25,7 +25,7 @@ use Twig\Environment;
 
 class ReadmeHtml implements GeneratedFileInterface
 {
-    public function __construct(private Environment $twig, private MarkdownExtra $markdown, private string $readmeMd)
+    public function __construct(private readonly Environment $twig, private readonly MarkdownExtra $markdown, private readonly string $readmeMd)
     {
     }
 

--- a/src/PHPDocker/Generator/Files/ReadmeMd.php
+++ b/src/PHPDocker/Generator/Files/ReadmeMd.php
@@ -25,7 +25,7 @@ use Twig\Environment;
 
 class ReadmeMd implements GeneratedFileInterface
 {
-    public function __construct(private Environment $twig, private Project $project)
+    public function __construct(private readonly Environment $twig, private readonly Project $project)
     {
     }
 

--- a/src/PHPDocker/Generator/Generator.php
+++ b/src/PHPDocker/Generator/Generator.php
@@ -41,10 +41,10 @@ class Generator
     private const ARCHIVE_FILENAME = 'phpdocker.zip';
 
     public function __construct(
-        private Archiver $archiver,
-        private Environment $twig,
-        private MarkdownExtra $markdownExtra,
-        private Dumper $yaml,
+        private readonly Archiver $archiver,
+        private readonly Environment $twig,
+        private readonly MarkdownExtra $markdownExtra,
+        private readonly Dumper $yaml,
     ) {
         $this->archiver->setBaseFolder(self::BASE_ZIP_FOLDER);
     }

--- a/src/PHPDocker/Project/Project.php
+++ b/src/PHPDocker/Project/Project.php
@@ -37,8 +37,8 @@ class Project
     private ServiceOptions\Clickhouse    $clickhouseOptions;
 
     public function __construct(
-        private Php $phpOptions,
-        private ServiceOptions\GlobalOptions $globalOptions,
+        private readonly Php $phpOptions,
+        private readonly ServiceOptions\GlobalOptions $globalOptions,
     ) {
         // Initialise project properties
         $this->nginxOptions         = new ServiceOptions\Nginx();

--- a/src/PHPDocker/Project/ServiceOptions/GlobalOptions.php
+++ b/src/PHPDocker/Project/ServiceOptions/GlobalOptions.php
@@ -6,7 +6,7 @@ namespace App\PHPDocker\Project\ServiceOptions;
 final class GlobalOptions extends Base
 {
 
-    public function __construct(private int $basePort, private string $appPath, private string $dockerWorkingDir)
+    public function __construct(private readonly int $basePort, private readonly string $appPath, private readonly string $dockerWorkingDir)
     {
     }
 

--- a/src/PHPDocker/Project/ServiceOptions/Php.php
+++ b/src/PHPDocker/Project/ServiceOptions/Php.php
@@ -54,8 +54,8 @@ class Php extends Base
     public function __construct(
         string $version,
         array $extensions,
-        private bool $hasGit,
-        private string $frontControllerPath
+        private readonly bool $hasGit,
+        private readonly string $frontControllerPath
     ) {
         $this->setEnabled(true);
 


### PR DESCRIPTION
As per title. This turns readonly a number of class properties, now that we are on php 8.2.