### PR TITLE
doc: fix php.ini settings for xdebug 3

### DIFF
--- a/src/PHPDocker/Template/README.md.twig
+++ b/src/PHPDocker/Template/README.md.twig
@@ -120,9 +120,10 @@ To configure **Xdebug 3** you need add these lines in php-fpm/php-ini-overrides.
 ### For linux:
 
 ```
-xdebug.mode = debug
-xdebug.remote_connect_back = true
-xdebug.start_with_request = yes
+xdebug.mode=debug
+xdebug.discover_client_host=true
+xdebug.start_with_request=yes
+xdebug.client_port=9000
 ```
 
 ### For macOS and Windows:
@@ -151,5 +152,21 @@ environment:
 * Select "Use path mappings" and set mappings between a path to your project on a host system and the Docker container.
 * Finally, add “Xdebug helper” extension in your browser, set breakpoints and start debugging
 
+### Create a launch.json for visual studio code
 
+  {
+      "version": "0.2.0",
+      "configurations": [
+          {
+              "name": "Docker",
+              "type": "php",
+              "request": "launch",
+              "port": 9000,
+              // Server Remote Path -> Local Project Path
+              "pathMappings": {
+                  "/application/public": "${workspaceRoot}/"
+              },
+          }
+      ]
+  }
 


### PR DESCRIPTION
The docu used deprecated parameters, which where not valid for xdebug 3

xdebug 3 as well changed the default port from 9000 to 90003. Because nginx is setup to expose port 9000 you need to set xdebug to port 9000 back to work propberly

and I added a example visual studio code launch.json, which worked for me.