### PR TITLE
Ensure docker build fails on error

### DIFF
--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -2,9 +2,9 @@ FROM phpdockerio/php:{{ phpVersion }}-fpm
 WORKDIR "{{ dockerWorkingDir }}"
 
 {% if packages %}
-RUN apt-get update && \
-    apt-get -y --no-install-recommends install \
-        {{ packages | join(' \\ \n        ') }} && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+RUN apt-get update \
+    && apt-get -y --no-install-recommends install \
+        {{ packages | join(' \\ \n        ') }} \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 {% endif %}

--- a/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
+++ b/src/PHPDocker/Template/dockerfile-php-fpm.conf.twig
@@ -2,9 +2,9 @@ FROM phpdockerio/php:{{ phpVersion }}-fpm
 WORKDIR "{{ dockerWorkingDir }}"
 
 {% if packages %}
-RUN apt-get update; \
+RUN apt-get update && \
     apt-get -y --no-install-recommends install \
-        {{ packages | join(' \\ \n        ') }}; \
-    apt-get clean; \
+        {{ packages | join(' \\ \n        ') }} && \
+    apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 {% endif %}


### PR DESCRIPTION
I'm not entirely sure why but the Dockerfile RUN commands were chained using semicolons instead of double ampersands - this resulted on builds that would never fail even if those commands failed, causing confusion to users.

Now, given this file:

```Dockerfile
FROM phpdockerio/php:8.2-fpm
WORKDIR "/application"

# gmagick and imagick conflict in APT and apt install fails
RUN apt-get update \
    && apt-get -y --no-install-recommends install \
        php8.2-bcmath \ 
        php8.2-gmagick \ 
        php8.2-imagick \
    && apt-get clean \
    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
```

Docker build fails now correctly:

![image](https://github.com/phpdocker-io/phpdocker.io/assets/6388823/a17b6a32-a6a4-47aa-903c-4d50ac7bef13)

Closes #349 
