### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,14 +18,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
           echo "::set-output name=dir::$(make composer-cache-dir)"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Get Composer Cache Directory
         id: composer-cache
         run: |
-          echo "::set-output name=dir::$(make composer-cache-dir)"
+          echo "dir=$(make composer-cache-dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
**Changes:**

 * `actions/cache@2` --> 3
 * `actions/checkout@1` --> 3
 * Address use of deprecated `set-output`

Closes https://github.com/phpdocker-io/phpdocker.io/issues/344