### PR TITLE
Update MariaDB versions: 10.4 to 11.0

### DIFF
--- a/src/PHPDocker/Project/ServiceOptions/MariaDB.php
+++ b/src/PHPDocker/Project/ServiceOptions/MariaDB.php
@@ -26,11 +26,6 @@ class MariaDB extends AbstractMySQL
     /**
      * Available versions
      */
-    private const VERSION_55   = '5.5';
-    private const VERSION_100  = '10.0';
-    private const VERSION_101  = '10.1';
-    private const VERSION_102  = '10.2';
-    private const VERSION_103  = '10.3';
     private const VERSION_104  = '10.4';
     private const VERSION_105  = '10.5';
     private const VERSION_106  = '10.6';
@@ -38,8 +33,12 @@ class MariaDB extends AbstractMySQL
     private const VERSION_108  = '10.8';
     private const VERSION_109  = '10.9';
     private const VERSION_1010 = '10.10';
+    private const VERSION_1011 = '10.11';
+    private const VERSION_110 = '11.0';
 
     private const ALLOWED_VERSIONS = [
+        self::VERSION_110 => '11.0.x',
+        self::VERSION_1011 => '10.11.x',
         self::VERSION_1010 => '10.10.x',
         self::VERSION_109  => '10.9.x',
         self::VERSION_108  => '10.8.x',
@@ -47,11 +46,6 @@ class MariaDB extends AbstractMySQL
         self::VERSION_106  => '10.6.x',
         self::VERSION_105  => '10.5.x',
         self::VERSION_104  => '10.4.x',
-        self::VERSION_103  => '10.3.x',
-        self::VERSION_102  => '10.2.x',
-        self::VERSION_101  => '10.1.x',
-        self::VERSION_100  => '10.0.x',
-        self::VERSION_55   => '5.5.x',
     ];
 
     /**
@@ -59,7 +53,7 @@ class MariaDB extends AbstractMySQL
      */
     public function __construct()
     {
-        $this->version = self::VERSION_1010;
+        $this->version = self::VERSION_110;
     }
 
     protected function getExternalPortOffset(): ?int


### PR DESCRIPTION
**Changes:**
 * Remove EOL versions of MariaDB
 * Add available stable versions of MariaDB

MariaDB versions now range from 10.4 to 11.0.

Closes https://github.com/phpdocker-io/phpdocker.io/issues/353