### PR TITLE
Register php.ini overrides with CLI, too

### DIFF
--- a/src/PHPDocker/Generator/Files/DockerCompose.php
+++ b/src/PHPDocker/Generator/Files/DockerCompose.php
@@ -213,6 +213,7 @@ class DockerCompose implements GeneratedFileInterface
             'volumes'     => [
                 $this->defaultVolume,
                 sprintf('./phpdocker/%s:/etc/php/%s/fpm/conf.d/99-overrides.ini', $this->phpIniLocation, $shortVersion),
+                sprintf('./phpdocker/%s:/etc/php/%s/cli/conf.d/99-overrides.ini', $this->phpIniLocation, $shortVersion),
             ],
         ];
 


### PR DESCRIPTION
Currently, the php-ini-overrides.ini file only applies to fpm.  It doesn't apply to the CLI.

It's quite rare to not want settings in both cases, especially if you're doing something like setting up XDebug.  This PR links the file for both modes.